### PR TITLE
Enforce Metronome only accepting JSON

### DIFF
--- a/packages/destination-actions/src/destinations/metronome/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/__tests__/index.test.ts
@@ -9,9 +9,11 @@ const testDestination = createTestIntegration(Definition)
 describe('Metronome', () => {
   describe('testAuthentication', () => {
     it('should validate valid auth tokens', async () => {
-      nock('https://api.getmetronome.com').post('/v1/ingest').reply(400, {
-        message: "[array is too short: must have at least 1 elements but instance has 0 elements]"
-      });
+      nock('https://api.getmetronome.com')
+        .matchHeader('content-type', 'application/json')
+        .post('/v1/ingest').reply(400, {
+          message: "[array is too short: must have at least 1 elements but instance has 0 elements]"
+        });
 
       const authData: Settings = {
         apiToken: "mock-token"
@@ -21,9 +23,12 @@ describe('Metronome', () => {
     })
 
     it('should throw an error for invalid auth tokens', async () => {
-      nock('https://api.getmetronome.com').post('/v1/ingest').reply(403, {
-        "message": "Unauthorized"
-      });
+      nock('https://api.getmetronome.com')
+        .post('/v1/ingest')
+        .matchHeader('content-type', 'application/json')
+        .reply(403, {
+          "message": "Unauthorized"
+        });
 
       const authData: Settings = {
         apiToken: "mock-token"

--- a/packages/destination-actions/src/destinations/metronome/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/index.ts
@@ -21,7 +21,7 @@ const destination: DestinationDefinition<Settings> = {
     testAuthentication: async (request) => {
       const response = await request('https://api.getmetronome.com/v1/ingest', {
         method: 'post',
-        body: JSON.stringify([]),
+        json: [],
         throwHttpErrors: false
       })
       // An empty set of events will return a 400 response whereas a bad token will return a 403.

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
@@ -9,7 +9,9 @@ describe('Metronome.sendEvent', () => {
     it('should send an event', async () => {
       const event = createTestEvent();
 
-      nock('https://api.getmetronome.com').post('/v1/ingest').reply(200)
+      nock('https://api.getmetronome.com')
+        .matchHeader('content-type', 'application/json')
+        .post('/v1/ingest').reply(200)
 
       const responses = await testDestination.testAction('sendEvent', {
         event,
@@ -57,7 +59,9 @@ describe('Metronome.sendEvent', () => {
         timestamp: "2021-01-01"
       });
 
-      nock('https://api.getmetronome.com').post('/v1/ingest').reply(200)
+      nock('https://api.getmetronome.com')
+        .matchHeader('content-type', 'application/json')
+        .post('/v1/ingest').reply(200)
 
       const responses = await testDestination.testAction('sendEvent', {
         event,
@@ -105,7 +109,9 @@ describe('Metronome.sendEvent', () => {
         }
       });
 
-      nock('https://api.getmetronome.com').post('/v1/ingest').reply(200)
+      nock('https://api.getmetronome.com')
+        .matchHeader('content-type', 'application/json')
+        .post('/v1/ingest').reply(200)
 
       const responses = await testDestination.testAction('sendEvent', {
         event,


### PR DESCRIPTION
Our API only works if you give it JSON. The `nock` mocks didn't enforce this. 

This wasn't noticed during manual testing because we _do_ send JSON correctly for the event ingestion call. We were just missing it during the auth check call. Updated the mocks, ensured the tests failed, then fixed the code.